### PR TITLE
generate sitemap.xml in production

### DIFF
--- a/app_generator.rb
+++ b/app_generator.rb
@@ -131,6 +131,12 @@ gsub_file 'config/database.yml', /\{\{db_password\}\}/, db_password
 
 rake('db:create:all')
 
+# Robots.txt with sitemap
+route "get '/robots', to: 'application\#robots', format: 'txt'"
+remove_file 'public/robots.txt'
+empty_directory_with_keep_file 'app/views/application'
+get_from_master_repo 'app/views/application/robots.txt.erb'
+
 # Run generators (after database creation)
 # generate 'simple_form:install --bootstrap'
 

--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -15,6 +15,12 @@ gem 'capistrano', '~> 2.15.5'
 gem 'dalli'
 gem 'exception_notification'
 
+# SEO
+gem 'sitemap_generator'
+
+# Cron
+gem 'whenever', require: false
+
 # Server
 gem 'unicorn' #staging and production
 gem 'thin', group: :development

--- a/templates/app/views/application/robot.txt.erb
+++ b/templates/app/views/application/robot.txt.erb
@@ -1,0 +1,8 @@
+# See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
+<% if Rails.env.production? %>
+Sitemap: <%= request.protocol %><%= request.host %>/sitemap.xml.gz
+<% else %>
+# Ban all spiders from the entire site
+User-agent: *
+Disallow: /
+<% end %>

--- a/templates/config/recipes/sitemap.rb
+++ b/templates/config/recipes/sitemap.rb
@@ -1,0 +1,13 @@
+namespace :sitemap do
+
+  # task :copy_old_sitemap do
+  #   run "if [ -e #{previous_release}/public/sitemap.xml.gz ]; then cp #{previous_release}/public/sitemap* #{current_release}/public/; fi"
+  # end
+  # after "deploy:update_code", "sitemap:copy_old_sitemap"
+
+
+  task :refresh_sitemaps do
+    run "cd #{latest_release} && RAILS_ENV=#{rails_env} rake sitemap:refresh"
+  end
+  after "deploy", "sitemap:refresh_sitemaps"
+end

--- a/templates/config/schedule.rb
+++ b/templates/config/schedule.rb
@@ -1,0 +1,4 @@
+# config/schedule.rb
+every 1.day, :at => '3:00 am' do
+  rake "-s sitemap:refresh"
+end

--- a/templates/config/sitemap.rb
+++ b/templates/config/sitemap.rb
@@ -1,0 +1,34 @@
+if Rails.env.production?
+  
+  # Set the host name for URL creation
+  SitemapGenerator::Sitemap.default_host = "http://#{Env.host}"
+
+  SitemapGenerator::Sitemap.create do
+    # Put links creation logic here.
+    #
+    # The root path '/' and sitemap index file are added automatically for you.
+    # Links are added to the Sitemap in the order they are specified.
+    #
+    # Usage: add(path, options={})
+    #        (default options are used if you don't specify)
+    #
+    # Defaults: :priority => 0.5, :changefreq => 'weekly',
+    #           :lastmod => Time.now, :host => default_host
+    #
+    # Examples:
+    #
+    # Add '/articles'
+    #
+    #   add articles_path, :priority => 0.7, :changefreq => 'daily'
+    #
+    # Add all articles:
+    #
+
+    # If you are using cardboard, uncomment the next lines
+    # Cardboard::Page.find_each do |page|
+    #   add page_path(page), :lastmod => page.updated_at
+    # end
+  end
+
+  SitemapGenerator::Sitemap.ping_search_engines
+end


### PR DESCRIPTION
I think we should add a sitemap.xml generator to the sb_app_generator.

http://en.wikipedia.org/wiki/Sitemaps

would make it faster to integrate then having to do this on every (public facing) site.
Thoughts?
