### PR TITLE
Removing double occurrence of faker gem

### DIFF
--- a/templates/Gemfile
+++ b/templates/Gemfile
@@ -100,7 +100,6 @@ group :test do
   gem 'database_cleaner'
   gem 'simplecov', require: false
   gem 'turn', require: false
-  gem 'faker'
   gem 'mocha'
 end
 


### PR DESCRIPTION
# Why?

Faker was listed in the `:development, :test` group and `:test` group. This caused warnings.
# What Changed?

Pulled the extra `gem 'faker'` statement from the `:test` group on line 103.
