### PR TITLE
Bundle capify

### DIFF
--- a/app_generator.rb
+++ b/app_generator.rb
@@ -76,7 +76,7 @@ EOS
 gsub_file 'config/environments/development.rb', /(\n\s*end)/, <<-EOS
 
   config.action_mailer.delivery_method = :letter_opener
-  
+
   #Uncomment to use absolute paths for assets, added for using asset pipeline in email templates.
   #Sets config.action_controller.asset_host and config.action_mailer.asset_host
   #config.asset_host = 'http://localhost:3000'


### PR DESCRIPTION
Run `capify .` with `bundle exec`
For us with multiple versions of Capistrano installed, `capify!` fails
when using Capistrano 3. Replacing `capify!` with the contents of
https://github.com/rails/rails/blob/master/railties/lib/rails/generators
/actions.rb#L208 + `bundle exec`
